### PR TITLE
Fix BYTE statistics on platforms with unsigned 'char'

### DIFF
--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -590,7 +590,7 @@ namespace orc {
         if (enableBloomFilter) {
           bloomFilter->addLong(data[i]);
         }
-        intStats->update(static_cast<int64_t>(byteData[i]), 1);
+        intStats->update(static_cast<int64_t>(static_cast<signed char>(byteData[i])), 1);
       }
     }
     intStats->increase(count);


### PR DESCRIPTION
ORC's BYTE type is signed, but the library used `char` type for calculating min/max values. It broke in ARM builds.