### PR TITLE
Improve string column dict encoding performance

### DIFF
--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -248,10 +248,15 @@ namespace orc {
     ~EncodedStringVectorBatch() override;
     std::string toString() const override;
     void resize(uint64_t capacity) override;
+
+    // Calculate data and length in StringVectorBatch from dictionary and index
+    void calculateDataAndLength();
+
     std::shared_ptr<StringDictionary> dictionary;
 
     // index for dictionary entry
     DataBuffer<int64_t> index;
+    std::atomic<bool> calculated{false};
   };
 
   struct StructVectorBatch : public ColumnVectorBatch {

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1112,6 +1112,12 @@ namespace orc {
       throw InvalidArgument("Failed to cast to StringVectorBatch");
     }
 
+    EncodedStringVectorBatch* encoded_string_batch =
+        dynamic_cast<EncodedStringVectorBatch*>(&rowBatch);
+    if (encoded_string_batch) {
+      encoded_string_batch->calculateDataAndLength();
+    }
+
     StringColumnStatisticsImpl* strStats =
         dynamic_cast<StringColumnStatisticsImpl*>(colIndexStatistics.get());
     if (strStats == nullptr) {
@@ -1460,6 +1466,12 @@ namespace orc {
       throw InvalidArgument("Failed to cast to StringVectorBatch");
     }
 
+    EncodedStringVectorBatch* encoded_string_batch =
+        dynamic_cast<EncodedStringVectorBatch*>(&rowBatch);
+    if (encoded_string_batch) {
+      encoded_string_batch->calculateDataAndLength();
+    }
+
     StringColumnStatisticsImpl* strStats =
         dynamic_cast<StringColumnStatisticsImpl*>(colIndexStatistics.get());
     if (strStats == nullptr) {
@@ -1536,6 +1548,12 @@ namespace orc {
     StringVectorBatch* charsBatch = dynamic_cast<StringVectorBatch*>(&rowBatch);
     if (charsBatch == nullptr) {
       throw InvalidArgument("Failed to cast to StringVectorBatch");
+    }
+
+    EncodedStringVectorBatch* encoded_string_batch =
+        dynamic_cast<EncodedStringVectorBatch*>(&rowBatch);
+    if (encoded_string_batch) {
+      encoded_string_batch->calculateDataAndLength();
     }
 
     StringColumnStatisticsImpl* strStats =

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -887,10 +887,16 @@ namespace orc {
       size_t length;
     };
 
+    struct DictEntryWithIndex {
+      DictEntryWithIndex(const char* str, size_t len, size_t index) : entry(str, len), index(index) {}
+      DictEntry entry;
+      size_t index;
+    };
+
     SortedStringDictionary() : totalLength(0) {}
 
     // insert a new string into dictionary, return its insertion order
-    size_t insert(const char* data, size_t len);
+    size_t insert(const char* str, size_t len);
 
     // write dictionary data & length to output buffer
     void flush(AppendOnlyBufferedStream* dataStream, RleEncoder* lengthEncoder) const;
@@ -911,7 +917,9 @@ namespace orc {
 
    private:
     struct LessThan {
-      bool operator()(const DictEntry& left, const DictEntry& right) const {
+      bool operator()(const DictEntryWithIndex& l, const DictEntryWithIndex& r) {
+        const auto& left = l.entry;
+        const auto& right = r.entry;
         int ret = memcmp(left.data, right.data, std::min(left.length, right.length));
         if (ret != 0) {
           return ret < 0;
@@ -920,8 +928,8 @@ namespace orc {
       }
     };
 
-    std::map<DictEntry, size_t, LessThan> dict;
-    std::vector<std::vector<char>> data;
+    mutable std::vector<DictEntryWithIndex> flat_dict;
+    std::unordered_map<std::string, size_t> key_to_index;
     uint64_t totalLength;
 
     // use friend class here to avoid being bothered by const function calls
@@ -934,14 +942,10 @@ namespace orc {
 
   // insert a new string into dictionary, return its insertion order
   size_t SortedStringDictionary::insert(const char* str, size_t len) {
-    auto ret = dict.insert({DictEntry(str, len), dict.size()});
+    size_t index = flat_dict.size();
+    auto ret = key_to_index.emplace(std::string(str, len), index);
     if (ret.second) {
-      // make a copy to internal storage
-      data.push_back(std::vector<char>(len));
-      memcpy(data.back().data(), str, len);
-      // update dictionary entry to link pointer to internal storage
-      DictEntry* entry = const_cast<DictEntry*>(&(ret.first->first));
-      entry->data = data.back().data();
+      flat_dict.emplace_back(ret.first->first.data(), ret.first->first.size(), index);
       totalLength += len;
     }
     return ret.first->second;
@@ -950,9 +954,12 @@ namespace orc {
   // write dictionary data & length to output buffer
   void SortedStringDictionary::flush(AppendOnlyBufferedStream* dataStream,
                                      RleEncoder* lengthEncoder) const {
-    for (auto it = dict.cbegin(); it != dict.cend(); ++it) {
-      dataStream->write(it->first.data, it->first.length);
-      lengthEncoder->write(static_cast<int64_t>(it->first.length));
+    std::sort(flat_dict.begin(), flat_dict.end(), LessThan());
+
+    for (const auto& entry_with_index : flat_dict) {
+      const auto& entry = entry_with_index.entry;
+      dataStream->write(entry.data, entry.length);
+      lengthEncoder->write(static_cast<int64_t>(entry.length));
     }
   }
 
@@ -968,10 +975,9 @@ namespace orc {
    */
   void SortedStringDictionary::reorder(std::vector<int64_t>& idxBuffer) const {
     // iterate the dictionary to get mapping from insertion order to value order
-    std::vector<size_t> mapping(dict.size());
-    size_t dictIdx = 0;
-    for (auto it = dict.cbegin(); it != dict.cend(); ++it) {
-      mapping[it->second] = dictIdx++;
+    std::vector<size_t> mapping(flat_dict.size());
+    for (size_t i = 0; i < flat_dict.size(); ++i) {
+      mapping[flat_dict[i].index] = i;
     }
 
     // do the transformation
@@ -983,15 +989,20 @@ namespace orc {
   // get dict entries in insertion order
   void SortedStringDictionary::getEntriesInInsertionOrder(
       std::vector<const DictEntry*>& entries) const {
-    entries.resize(dict.size());
-    for (auto it = dict.cbegin(); it != dict.cend(); ++it) {
-      entries[it->second] = &(it->first);
+    std::sort(flat_dict.begin(), flat_dict.end(),
+              [](const DictEntryWithIndex& left, const DictEntryWithIndex& right) {
+                return left.index < right.index;
+              });
+
+    entries.resize(flat_dict.size());
+    for (size_t i = 0; i < flat_dict.size(); ++i) {
+      entries[i] = &(flat_dict[i].entry);
     }
   }
 
   // return count of entries
   size_t SortedStringDictionary::size() const {
-    return dict.size();
+    return flat_dict.size();
   }
 
   // return total length of strings in the dictioanry
@@ -1001,8 +1012,8 @@ namespace orc {
 
   void SortedStringDictionary::clear() {
     totalLength = 0;
-    data.clear();
-    dict.clear();
+    key_to_index.clear();
+    flat_dict.clear();
   }
 
   class StringColumnWriter : public ColumnWriter {

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -87,6 +87,21 @@ namespace orc {
     }
   }
 
+  void EncodedStringVectorBatch::calculateDataAndLength() {
+    if (calculated)
+        return;
+
+    size_t n = index.size();
+    resize(n);
+
+    for (size_t i = 0; i < n; ++i) {
+      if (!hasNulls || notNull[i]) {
+        dictionary->getValueByIndex(index[i], data[i], length[i]);
+      }
+    }
+    calculated = true;
+  }
+
   StringVectorBatch::StringVectorBatch(uint64_t _capacity, MemoryPool& pool)
       : ColumnVectorBatch(_capacity, pool),
         data(pool, _capacity),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve writing performance of encoded string column. Speed up by 2x 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### How was this patch tested? 

I tested it with clickhouse branch: https://github.com/ClickHouse/ClickHouse/pull/68591 

Query:
``` sql 
set output_format_orc_dictionary_key_size_threshold = 1;
select concat('gluten ', cast(rand()%1000 as String)) from numbers(10000000) into outfile 'dict.orc' truncate;
```

Before current optimization: 
```
10000000 rows in set. Elapsed: 2.794 sec. Processed 10.00 million rows, 80.00 MB (3.58 million rows/s., 28.63 MB/s.)
Peak memory usage: 9.07 MiB.
```

After current optimization: 
```
10000000 rows in set. Elapsed: 1.423 sec. Processed 10.00 million rows, 80.00 MB (7.02 million rows/s., 56.20 MB/s.)
Peak memory usage: 9.07 MiB.
```



<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
