### PR TITLE
Bound type-tree nesting depth when reading the footer

### DIFF
--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -420,7 +420,20 @@ namespace orc {
   }
 
   std::string printProtobufMessage(const google::protobuf::Message& message);
-  std::unique_ptr<Type> convertType(const proto::Type& type, const proto::Footer& footer) {
+  // Bound the recursion over the (file-controlled) type tree. The footer describes the schema as a
+  // tree of LIST/MAP/UNION/STRUCT types nested arbitrarily deep; a crafted deeply nested schema
+  // would overflow the native stack here, and later in assignIds()/buildTypeNameIdMap() which walk
+  // the same tree. The limit is far above any legitimate schema.
+  static const uint64_t MAX_TYPE_NESTING_DEPTH = 2000;
+
+  std::unique_ptr<Type> convertType(const proto::Type& type, const proto::Footer& footer,
+                                    uint64_t depth) {
+    if (depth > MAX_TYPE_NESTING_DEPTH) {
+      std::stringstream msg;
+      msg << "Footer is corrupt: type nesting depth exceeds the limit of " << MAX_TYPE_NESTING_DEPTH;
+      throw ParseError(msg.str());
+    }
+
     std::unique_ptr<Type> ret;
     switch (static_cast<int64_t>(type.kind())) {
       case proto::Type_Kind_BOOLEAN:
@@ -458,7 +471,8 @@ namespace orc {
         if (type.kind() == proto::Type_Kind_UNION && type.subtypes_size() == 0)
           throw ParseError("Illegal UNION type that doesn't contain any subtypes");
         for (int i = 0; i < type.subtypes_size(); ++i) {
-          ret->addUnionChild(convertType(footer.types(static_cast<int>(type.subtypes(i))), footer));
+          ret->addUnionChild(
+              convertType(footer.types(static_cast<int>(type.subtypes(i))), footer, depth + 1));
         }
         break;
       }
@@ -470,7 +484,7 @@ namespace orc {
         for (int i = 0; i < type.subtypes_size(); ++i) {
           ret->addStructField(
               type.field_names(i),
-              convertType(footer.types(static_cast<int>(type.subtypes(i))), footer));
+              convertType(footer.types(static_cast<int>(type.subtypes(i))), footer, depth + 1));
         }
         break;
       }

--- a/c++/src/TypeImpl.hh
+++ b/c++/src/TypeImpl.hh
@@ -187,7 +187,8 @@ namespace orc {
                                                size_t start, size_t end);
   };
 
-  std::unique_ptr<Type> convertType(const proto::Type& type, const proto::Footer& footer);
+  std::unique_ptr<Type> convertType(const proto::Type& type, const proto::Footer& footer,
+                                     uint64_t depth = 0);
 
   /**
    * Build a clone of the file type, projecting columns from the selected


### PR DESCRIPTION
According to https://github.com/apache/orc/pull/2632 the library vulnerabilities are not such:
```
A crash, Out-Of-Memory (OOM), Out-Of-Bounds (OOB) read, or assertion failure caused by feeding a maliciously fuzzed file directly into the low-level parser is considered a **robustness issue** (a regular software bug), not a security vulnerability.
```

Our model does not match this, and we handle any input. Thus we must prevent stack overflows when parsing types