### PR TITLE
Reject out-of-range column id in StripeInformationImpl::getColumnEncoding

### DIFF
--- a/c++/src/StripeStream.hh
+++ b/c++/src/StripeStream.hh
@@ -19,6 +19,8 @@
 #ifndef ORC_STRIPE_STREAM_HH
 #define ORC_STRIPE_STREAM_HH
 
+#include <sstream>
+
 #include "orc/Int128.hh"
 #include "orc/OrcFile.hh"
 #include "orc/Reader.hh"
@@ -140,6 +142,19 @@ namespace orc {
     ReaderMetrics* metrics_;
     void ensureStripeFooterLoaded() const;
 
+    // A corrupt or truncated file can declare more columns in the file type tree than there are
+    // ColumnEncoding entries in the stripe footer. Indexing the footer with such a column id would
+    // hit an out-of-range protobuf access and abort the process, so reject it with a ParseError.
+    void checkColumnEncodingId(uint64_t colId) const {
+      const auto columnCount = static_cast<uint64_t>(stripeFooter_->columns_size());
+      if (colId >= columnCount) {
+        std::stringstream msg;
+        msg << "Column id " << colId << " is out of range: the stripe footer has " << columnCount
+            << " column encodings";
+        throw ParseError(msg.str());
+      }
+    }
+
    public:
     StripeInformationImpl(uint64_t offset, uint64_t indexLength, uint64_t dataLength,
                           uint64_t footerLength, uint64_t numRows, InputStream* stream,
@@ -194,12 +209,14 @@ namespace orc {
 
     ColumnEncodingKind getColumnEncoding(uint64_t colId) const override {
       ensureStripeFooterLoaded();
+      checkColumnEncodingId(colId);
       return static_cast<ColumnEncodingKind>(
           stripeFooter_->columns(static_cast<int>(colId)).kind());
     }
 
     uint64_t getDictionarySize(uint64_t colId) const override {
       ensureStripeFooterLoaded();
+      checkColumnEncodingId(colId);
       return static_cast<ColumnEncodingKind>(
           stripeFooter_->columns(static_cast<int>(colId)).dictionary_size());
     }


### PR DESCRIPTION
A corrupt or truncated ORC file can declare more columns in the file type tree than there are `ColumnEncoding` entries in the stripe footer. `getColumnEncoding` and `getDictionarySize` indexed `stripeFooter_->columns(colId)` directly, so such a column id hit an out-of-range protobuf `RepeatedPtrField::Get` and aborted the process via an absl CHECK (SIGABRT).

Bound-check the id against `columns_size()` and throw a `ParseError` instead, matching how the sibling stream accessors (`getStreamInformation`) already reject malformed footers.

Found via the ClickHouse AST fuzzer: a fuzzed ORC blob fed to `format('ORC', ...)` reaches `getColumnEncoding` through ClickHouse's schema inference (`isDictionaryEncoded`) for a STRING column and crashes the server. Repro (minimal ORC: root STRUCT with one STRING child, stripe footer with only 1 ColumnEncoding) now returns a clean parse error instead of aborting.